### PR TITLE
Fix resource counts

### DIFF
--- a/Tests/AzurePSDrive.Tests.ps1
+++ b/Tests/AzurePSDrive.Tests.ps1
@@ -340,7 +340,7 @@ Describe Get-ResourceType {
         # Verify Network Type
         cd "Azure:\$subscriptionName\ResourceGroups\$resourceGroupName\Microsoft.Network"
         $resourceTypes = dir -Force              
-        $resourceTypes.Count | Should Be 4
+        $resourceTypes.Count | Should Be 3
 
         # Only following resourceTypes must be returned, since we initialized only these in 'Initialize-AzureTestResource'
         $expected = @('networkInterfaces', 'publicIPAddresses', 'virtualNetworks', 'networkSecurityGroups')
@@ -484,9 +484,9 @@ Describe Get-AllResourcesWithRecurse {
     It "Retrieving all resources with Recurse switch from ResourceGroup top level" {
 
         $allResources = dir -Recurse -Force
-        # There are 41 resources deployed in Azure as part of 'Initialize-AzureTestResource'
+        # There are 15 resources deployed in Azure as part of 'Initialize-AzureTestResource'
         # This includes Storage, Network, Compute resources
-        $allResources.Count | Should Be 41
+        $allResources.Count | Should Be 15
         
     }    
     


### PR DESCRIPTION
This fixes the resource counts for 2 of the tests. I ran this on our automation system, and it failed on these 2 tests. The numbers I had in my original PR were these numbers... seems like a merge issue?