### PR TITLE
Remove 'networkSecurityGroups'

### DIFF
--- a/Tests/AzurePSDrive.Tests.ps1
+++ b/Tests/AzurePSDrive.Tests.ps1
@@ -343,7 +343,7 @@ Describe Get-ResourceType {
         $resourceTypes.Count | Should Be 3
 
         # Only following resourceTypes must be returned, since we initialized only these in 'Initialize-AzureTestResource'
-        $expected = @('networkInterfaces', 'publicIPAddresses', 'virtualNetworks', 'networkSecurityGroups')
+        $expected = @('networkInterfaces', 'publicIPAddresses', 'virtualNetworks')
         $actual = @()
         foreach ($resourceType in $resourceTypes)
         {


### PR DESCRIPTION
Apparently, this value was part of the one Get-ResourceType test. It wasn't in my original PR and is causing the test to fail. Probably another merge issue...