### PR TITLE
Move Azure context check into the root constructor so it occurs at runtime instead of module load time.

### DIFF
--- a/AzurePSDrive.psm1
+++ b/AzurePSDrive.psm1
@@ -9,13 +9,6 @@ $script:AzureRM_Resources = if($IsCoreCLR){'AzureRM.Resources.Netcore'}else{'Azu
 $script:pathPattern = [System.IO.Path]::Combine('Azure:', '*', 'ResourceGroups', '*')
 $script:pathSeparator = if([System.IO.Path]::DirectorySeparatorChar -eq '\'){'\\'}else{'/'}
 
-# Ensure Session is logged-on to access Azure resources
-$context = (& "$script:AzureRM_Profile\Get-AzureRmContext")
-if ([string]::IsNullOrEmpty($($context.Account)))
-{
-    throw "Ensure that session has access to Azure resources - use $script:AzureRM_Profile\Add-AzureRMAccount or $script:AzureRM_Profile\Login-AzureRMAccount"
-}
-
 # Automatically pick resource group when inside resourcegroups of Azure drive
 $Global:PSDefaultParameterValues['*-AzureRM*:ResourceGroupName'] = {if($pwd -like $script:pathPattern){($pwd -split $script:pathSeparator)[3]}}
 
@@ -24,6 +17,13 @@ class Azure : SHiPSDirectory
 {
     Azure([string]$name): base($name)
     {        
+        # Ensure Session is logged-on to access Azure resources
+        # This is done in the constructor so that it is a runtime check and not done during module import.
+        $context = (& "$script:AzureRM_Profile\Get-AzureRmContext")
+        if ([string]::IsNullOrEmpty($($context.Account)))
+        {
+            throw "Ensure that session has access to Azure resources - use $script:AzureRM_Profile\Add-AzureRMAccount or $script:AzureRM_Profile\Login-AzureRMAccount"
+        }
     } 
 
     [object[]] GetChildItem()


### PR DESCRIPTION
This PR moves the AzureRMContext check into the constructor of the Azure class so that the check is done when attempting to run the provider instead of when the provider is imported.

### The new behavior:

``` powershell
PS AzurePSDrive> ipmo .\AzurePSDrive.psd1
PS AzurePSDrive> New-PSDrive -Name "TestAzureNoLogin" -PSProvider SHiPS -Root AzurePSDrive#Azure
New-PSDrive : Ensure that session has access to Azure resources - use AzureRM.Profile\Add-AzureRMAccount or
AzureRM.Profile\Login-AzureRMAccount
At line:1 char:1
+ New-PSDrive -Name "TestAzureNoLogin" -PSProvider SHiPS -Root AzurePSD ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Ensure that ses...-AzureRMAccount:String) [New-PSDrive], RuntimeExcep
   tion
    + FullyQualifiedErrorId : Ensure that session has access to Azure resources - use AzureRM.Profile\Add-AzureRMAccou
   nt or AzureRM.Profile\Login-AzureRMAccount,Microsoft.PowerShell.Commands.NewPSDriveCommand
```